### PR TITLE
ci: Ensure test step fails on command failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           cacheFrom: ghcr.io/minhanuvem/cloudflare-devcontainer
           push: never
           runCmd: |
+            set -eo pipefail
             npm test
             npm run check
             npm run check:docs


### PR DESCRIPTION
Add 'set -eo pipefail' to the runCmd in the CI workflow to ensure that
the build fails immediately if any of the test or check commands fail.
Previously, all commands would run regardless of failures, and the step
would pass if only the final command succeeded.