### PR TITLE
chore: Format renovate.json to comply with Biome style

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,7 +16,9 @@
       "customType": "regex",
       "description": "Track npm packages installed in GitHub Actions workflows",
       "fileMatch": ["\\.github/workflows/.+\\.yml$"],
-      "matchStrings": ["npm install -g (?<depName>@?[a-z0-9-]+\\/[a-z0-9-]+)@(?<currentValue>[0-9.]+)"],
+      "matchStrings": [
+        "npm install -g (?<depName>@?[a-z0-9-]+\\/[a-z0-9-]+)@(?<currentValue>[0-9.]+)"
+      ],
       "datasourceTemplate": "npm"
     }
   ],


### PR DESCRIPTION
The matchStrings array in the custom manager configuration was
not formatted according to Biome's style rules. This issue was
exposed after commit e0cc514 added stricter CI failure detection
with 'set -eo pipefail'.