### PR TITLE
chore: Migrate Dev Container from digest to human-readable tag

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,1 @@
-# renovate: datasource=docker depName=mcr.microsoft.com/devcontainers/javascript-node
-# 22.20.0-bookworm
-FROM mcr.microsoft.com/devcontainers/javascript-node@sha256:8ecd955dc231543929c46db04ab1a8962642bed804a84cdebb87a971dd5916d8
+FROM mcr.microsoft.com/devcontainers/javascript-node:4.0.5-22-bookworm

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,6 @@
     "config:recommended",
     "customManagers:biomeVersions",
     "helpers:pinGitHubActionDigests",
-    "docker:pinDigests",
     "schedule:weekly"
   ],
   "semanticCommits": "enabled",
@@ -13,14 +12,6 @@
     "enabled": true
   },
   "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["(^|/)\\.devcontainer/Dockerfile$"],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)\\s+# (?<currentValue>.+?)\\s+FROM (?<packageName>.+?)@(?<currentDigest>sha256:[a-f0-9]+)"
-      ],
-      "autoReplaceStringTemplate": "# renovate: datasource={{{datasource}}} depName={{{depName}}}\n# {{{newValue}}}\nFROM {{{packageName}}}@{{{newDigest}}}"
-    },
     {
       "customType": "regex",
       "description": "Track npm packages installed in GitHub Actions workflows",
@@ -54,7 +45,7 @@
     },
     {
       "description": "Dev Container images use chore(deps) prefix",
-      "matchManagers": ["devcontainer", "custom.regex"],
+      "matchManagers": ["devcontainer", "dockerfile"],
       "matchFileNames": [".devcontainer/**"],
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps"


### PR DESCRIPTION
Simplify Renovate configuration by using the built-in dockerfile manager
with human-readable tags instead of digests and custom regex managers.