### PR TITLE
fix: run Dev Container image as non-root node user

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,3 @@
 FROM mcr.microsoft.com/devcontainers/javascript-node:4.0.8-22-bookworm
+
+USER node


### PR DESCRIPTION
The `mcr.microsoft.com/devcontainers/javascript-node` image ships a pre-created non-root user called `node`. This adds `USER node` to the Dockerfile so the published image defaults to non-root when rebuilt.

Fixes #59.

🤖 Generated with [Claude Code](https://claude.ai/code)