### PR TITLE
docs: add IAM and messaging service specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,3 +30,7 @@ Commands that depend on host-level environment variables, processes, and/or file
 ## Language
 
 British English MUST be used throughout the codebase, except when using pre-existing terms such as "MIT License".
+
+## References
+
+-[The Messaging Layer Security (MLS) Architecture](https://github.com/mlswg/mls-architecture/raw/refs/heads/main/draft-ietf-mls-architecture.md).

--- a/product.md
+++ b/product.md
@@ -29,18 +29,11 @@ Any app used by individuals or households, whose data should be in the cloud for
 
 ### IAM
 
-- Clients. Each has its own long-lived IAM identity and MLS identity key pairs. An IAM client is the same as an MLS user (TBC).
-- Users. Each user has zero or more clients, with which they access the services. Can't have human-friendly names for privacy reasons.
-- Roles. Each role can be assigned to zero or more users.
-- Policies. Describe what roles are allowed to do with the resources. Can't be attached to clients. Could use Cedar policy language.
-
-To be clear, the MLS Authentication Service would be implemented here.
+[IAM service spec](./specs/01-iam.md).
 
 ### Messaging
 
-MLS Delivery Service.
-
-Can send messages to local clients, webhooks, SNS topics, etc.
+[Messaging service spec](./specs/02-messaging.md).
 
 ### Document Repository
 

--- a/specs/01-iam.md
+++ b/specs/01-iam.md
@@ -1,0 +1,11 @@
+# Nuvem IAM Service
+
+- Clients. Each has its own long-lived IAM identity, and zero-to-many MLS clients.
+- Users. Each user has zero or more clients, with which they access the services. Can't have human-friendly names for privacy reasons.
+- Roles. Each role can be assigned to zero or more users.
+- Policies. Describe what roles are allowed to do with the resources. Can't be attached to clients. Could use Cedar policy language.
+
+## MLS Authentication Service
+
+- X.509 certificates as credentials.
+- Well-known endpoint `nuvem-mls-id` to get MLS id CAs, so that clients can authenticate each other. This will enable federation.

--- a/specs/02-messaging.md
+++ b/specs/02-messaging.md
@@ -1,0 +1,17 @@
+# Nuvem Messaging Service
+
+MLS Delivery Service.
+
+Can send messages to local clients, webhooks, SNS topics, etc.
+
+## MLS Delivery Service
+
+### Directory subservice
+
+Stores and provides the initial keying material for clients.
+
+Clients upload KeyPackage on demand, and bound to a specific recipient, unlike protocols like Signal where the equivalent is uploaded pre-emptively. No "last resort" keys used.
+
+### Routing subservice
+
+Routes messages to the appropriate MLS group based on the recipient's MLS ID.


### PR DESCRIPTION
Extracts the IAM and messaging sections from `product.md` into dedicated spec files under `specs/`, and adds the MLS Architecture RFC as a reference in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.ai/code)